### PR TITLE
Guard access to EntityManager.

### DIFF
--- a/src/Engine/ItemModel/ItemEntry.cpp
+++ b/src/Engine/ItemModel/ItemEntry.cpp
@@ -47,7 +47,8 @@ std::vector<Ra::Core::Utils::Index> getItemROs( const Engine::RadiumEngine* /*en
 bool ItemEntry::isValid() const {
     ON_DEBUG( checkConsistency() );
     Engine::RadiumEngine* engine = Engine::RadiumEngine::getInstance();
-    return m_entity != nullptr                                                // It has an entity
+    return m_entity != nullptr           // It has an entity
+           && engine->getEntityManager() // Is entityManager up ?
            && engine->getEntityManager()->entityExists( m_entity->getName() ) // The entity exists
            && ( ( !isRoNode() ||
                   engine->getRenderObjectManager()->exists( m_roIndex ) ) ); // The RO exists

--- a/src/GuiBase/BaseApplication.cpp
+++ b/src/GuiBase/BaseApplication.cpp
@@ -117,7 +117,7 @@ BaseApplication::BaseApplication( int argc,
                                "Open a camera file at startup",
                                "file name",
                                "foo.bar" );
-    QCommandLineOption recordOpt( "recordFrames", "Enable snapshot recording." );
+    QCommandLineOption recordOpt( QStringList{"s", "recordFrames"}, "Enable snapshot recording." );
 
     parser.addOptions( {fpsOpt,
                         pluginOpt,

--- a/src/GuiBase/BaseApplication.hpp
+++ b/src/GuiBase/BaseApplication.hpp
@@ -122,6 +122,9 @@ class RA_GUIBASE_API BaseApplication : public QApplication
 
     void setContinuousUpdate( bool b ) {
         b ? m_continuousUpdateRequest++ : m_continuousUpdateRequest--;
+        // if continuous update is requested, then we need an update, if not,
+        // let update needed stay in the same state.
+        if ( m_continuousUpdateRequest > 0 ) m_isUpdateNeeded.store( true );
     }
     void askForUpdate() { m_isUpdateNeeded.store( true ); }
 


### PR DESCRIPTION

* **What is the new behavior (if this is a feature change)?**
If someone what to run continuously n frames with then record option is also needed.
If just the number of frames is provided, lazy update is made.